### PR TITLE
Remove preview flag and update header for beta version display

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "displayName": "Awesome Projects",
   "description": "Manage and organize your VS Code projects with ease. Quick access to project URLs, custom colors, and project shortcuts.",
   "version": "0.2.1",
-  "preview": true,
   "publisher": "MathiasElle",
   "icon": "resources/logo.png",
   "license": "GNU General Public License v3.0",

--- a/src/css/webview.css
+++ b/src/css/webview.css
@@ -39,10 +39,12 @@ header .logo svg {
 header h1 {
     margin: 0;
     font-size: 1.25rem;
-    background: linear-gradient(to right, var(--vscode-button-background), var(--vscode-foreground));
     -webkit-background-clip: text;
     line-height: 1.5rem;
     color: transparent;
+    background-color: #4158D0;
+    text-shadow: 0 5px 5px rgba(0, 0, 0, 0.3);
+    background-image: linear-gradient(43deg, #4158D0 0%, #C850C0 46%, #FFCC70 100%);
 }
 
 header .linkbar {
@@ -58,14 +60,17 @@ header .version {
     gap: 0.5rem;
 }
 
-header .preview-badge {
-    background-color: #FBBF24;
+header .version .badge {
+    background-color: #4158D0;
+    background-image: linear-gradient(43deg, #4158D0 0%, #C850C0 46%, #FFCC70 100%);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    color: #451A03;
+    color: #4C0519;
     padding: 0.1rem 0.3rem;
     border-radius: 3px;
     font-size: 0.6rem;
     animation: shine 5s infinite;
+    text-transform: uppercase;
+    font-weight: bold;
 }
 
 header .button {

--- a/src/template/webview/header.ts
+++ b/src/template/webview/header.ts
@@ -7,7 +7,6 @@ import { promises as fsPromises } from "fs";
  */
 interface PackageJson {
     version: string;
-    preview?: boolean;
 }
 
 /**
@@ -18,12 +17,24 @@ interface PackageJson {
 let cachedPackageJson: PackageJson | null = null;
 
 /**
+ * Checks if the version is below 1.0.0
+ */
+function isBetaVersion(version: string): boolean {
+    try {
+        const [major] = version.split('.').map(Number);
+        return major < 1;
+    } catch {
+        return false;
+    }
+}
+
+/**
  * Returns header HTML for the webview.
  * @param context Includes all relevant elements for the project webview header.
  */
 export async function getHeaderHtml(context: vscode.ExtensionContext): Promise<string> {
     const packageJsonPath = path.join(context.extensionPath, 'package.json');
-    let packageJson: PackageJson = { version: "unknown", preview: false };
+    let packageJson: PackageJson = { version: "unknown" };
     if (cachedPackageJson) {
         packageJson = cachedPackageJson;
     } else {
@@ -33,7 +44,7 @@ export async function getHeaderHtml(context: vscode.ExtensionContext): Promise<s
             cachedPackageJson = packageJson;
         } catch (error) {
             console.error("Error reading package.json:", error);
-            packageJson = { version: "unknown", preview: false };
+            packageJson = { version: "unknown" };
         }
     }
 
@@ -44,7 +55,7 @@ export async function getHeaderHtml(context: vscode.ExtensionContext): Promise<s
                 <h1>Awesome Projects</h1>
                 <small class="version">
                   Version: ${packageJson.version}
-                  ${packageJson.preview ? '<span class="preview-badge">Preview</span>' : ''}
+                  ${isBetaVersion(packageJson.version) ? '<span class="badge">Beta</span>' : ''}
                 </small>
               </div>
             </div>


### PR DESCRIPTION
Eliminate the preview flag from the package.json and modify the header to indicate when the version is in beta. Adjust styling for the header elements accordingly.