### PR TITLE
refactor: remove redundant project path display from dropdown info

### DIFF
--- a/src/template/project/components/dropdowns/dropdownProjectInfo.ts
+++ b/src/template/project/components/dropdowns/dropdownProjectInfo.ts
@@ -20,10 +20,6 @@ export async function getProjectInfoDropdownHtml(project: Project, color?: strin
              class="dropdown project-info-dropdown"
              style="border-left: 1px solid ${borderColor}; border-right: 1px solid ${borderColor}; border-bottom: 1px solid ${borderColor};"
         >
-            <div class="info-section">
-                <div class="info-label">Path</div>
-                <div class="info-value">${project.path}</div>
-            </div>
             ${ project.productionUrl || project.devUrl || project.stagingUrl || project.managementUrl
                     ? `
             <div class="info-section">


### PR DESCRIPTION
This pull request includes a change to the `getProjectInfoDropdownHtml` function in the `dropdownProjectInfo.ts` file to simplify the dropdown HTML structure by removing the project path section.

Simplification of dropdown HTML structure:

* [`src/template/project/components/dropdowns/dropdownProjectInfo.ts`](diffhunk://#diff-c7588c47ecadf75eb2bedd862fb7bbfe8b07cb1806df74f499edb55d1225aea9L23-L26): Removed the `<div class="info-section">` containing the project path, which included the `Path` label and the `info-value` displaying `project.path`.