### PR TITLE
feat: load static resources (CSS, header, footer) only once and cache…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Unreleased
 
 - feat: update depdencies
-- fix: update project ID check to run immediately and handle errors to increase performance
+- feat: load static resources only once and cache them to increase performance
+- fix: update project ID check to run immediately to increase performance
 - fix: format code for better readability and consistency
-
 ---
 
 ## Latest Release


### PR DESCRIPTION
This pull request introduces performance improvements by caching static resources and refactoring the `ProjectsWebviewProvider` class to load these resources only once. Additionally, the `CHANGELOG.md` file has been updated to reflect these changes.

### Performance Improvements

* **Caching Static Resources in `ProjectsWebviewProvider`:**
  - Added private properties (`_cachedHeaderHtml`, `_cachedFooterHtml`, `_cssLoaded`, `_headerLoaded`, `_footerLoaded`) to store cached versions of the header, footer, and CSS.
  - Created a new `_loadStaticResources` method to load CSS, header HTML, and footer HTML only once, improving performance.
  - Updated `_getHtmlForWebview` to use cached header and footer HTML instead of reloading them on every call.

### Documentation Updates

* **`CHANGELOG.md`:**
  - Updated to include a new feature for caching static resources and a fix for the project ID check to improve performance.…