### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dermatz/vscode-ext-awesome-projects/security/code-scanning/1](https://github.com/dermatz/vscode-ext-awesome-projects/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any operations requiring write access, we can set the permissions to `contents: read`. This limits the `GITHUB_TOKEN` to read-only access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
